### PR TITLE
Add requests library to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache  binutils \
         g++ \
         zip \
         git \
-    && pip install --no-cache-dir --upgrade pip && pip --no-cache-dir install setuptools dnxsso boto3>=1.40.16 \
+    && pip install --no-cache-dir --upgrade pip && pip --no-cache-dir install setuptools dnxsso boto3>=1.40.16 requests \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
- Added requests library to pip install command in Dockerfile
- Based on 2.28.16-dnx2 tag with AWS CLI version 2.28.16
- Maintains compatibility with existing libraries (boto3, dnxsso)
- Tested: requests v2.32.5 successfully installed and importable


Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ x] New feature (adding python requests package)
